### PR TITLE
ClockwareItem: Use faster RNG for UUIDs

### DIFF
--- a/src/main/java/mors/clockware/item/ClockwareItem.java
+++ b/src/main/java/mors/clockware/item/ClockwareItem.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.Level;
+import net.minecraft.util.Mth;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
@@ -25,7 +26,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.Random;
 
 public class ClockwareItem extends Item {
     private final int level;
@@ -103,14 +103,14 @@ public class ClockwareItem extends Item {
         if (stack == null || stack.isEmpty()) return;
         var type = Clockware_Components.CLOCKWARE_UUID.get();
         if (!stack.has(type)) {
-            stack.set(type, new ClockwareUUID(new UUID(RANDOM.nextLong(), RANDOM.nextLong())));
+            stack.set(type, new ClockwareUUID(Mth.createInsecureUUID()));
         }
     }
 
     @Override
     public @NotNull ItemStack getDefaultInstance() {
         ItemStack stack = super.getDefaultInstance();
-        stack.set(Clockware_Components.CLOCKWARE_UUID.get(), new ClockwareUUID(new UUID(RANDOM.nextLong(), RANDOM.nextLong())));
+        stack.set(Clockware_Components.CLOCKWARE_UUID.get(), new ClockwareUUID(Mth.createInsecureUUID()));
         return stack;
     }
 

--- a/src/main/java/mors/clockware/item/ClockwareItem.java
+++ b/src/main/java/mors/clockware/item/ClockwareItem.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.Random;
 
 public class ClockwareItem extends Item {
     private final int level;
@@ -96,18 +97,20 @@ public class ClockwareItem extends Item {
         }
     }
 
+    private static final Random RANDOM = new Random();
+
     public static void ensureHasUUID(ItemStack stack) {
         if (stack == null || stack.isEmpty()) return;
         var type = Clockware_Components.CLOCKWARE_UUID.get();
         if (!stack.has(type)) {
-            stack.set(type, new ClockwareUUID(UUID.randomUUID()));
+            stack.set(type, new ClockwareUUID(new UUID(RANDOM.nextLong(), RANDOM.nextLong())));
         }
     }
 
     @Override
     public @NotNull ItemStack getDefaultInstance() {
         ItemStack stack = super.getDefaultInstance();
-        stack.set(Clockware_Components.CLOCKWARE_UUID.get(), new ClockwareUUID(UUID.randomUUID()));
+        stack.set(Clockware_Components.CLOCKWARE_UUID.get(), new ClockwareUUID(new UUID(RANDOM.nextLong(), RANDOM.nextLong())));
         return stack;
     }
 


### PR DESCRIPTION
UUID.randomUUID() uses a secure RNG that's more costly than needed here.  This PR replaces it with a standard `java.util.Random`.